### PR TITLE
Fixed E_STRICT errors

### DIFF
--- a/lib/class.core.php
+++ b/lib/class.core.php
@@ -392,7 +392,7 @@ class AECCore {
 		Returns - Enumeration (0=unsuccessful,1=successful,or string error code)
 		*/
 		//public static class.core
-		function can_edit($commentID = 0, $postID = 0) {
+		public static function can_edit($commentID = 0, $postID = 0) {
 			global $wpdb, $aecomments;
 			
 			//Check if admin/editor/post author

--- a/lib/class.core.php
+++ b/lib/class.core.php
@@ -15,7 +15,7 @@ class AECCore {
 		public static function build_admin_links($commentID, $postID, $content = '') {
 			global $aecomments;
 			
-			$comment = &get_comment( $commentID );
+			$comment = get_comment( $commentID );
 			$ajax_url = admin_url( 'admin-ajax.php' ) . '?';
 			$plugin_url = $aecomments->get_plugin_url( '/views/' );
 			if (!AECCore::is_comment_owner($postID)) {


### PR DESCRIPTION
1. **E_STRICT** Non-static method AECCore::can_edit() should not be called statically - /var/www/html/wp-content/plugins/wp-ajax-edit-comments/lib/class.filters.php:9

2. **E_STRICT** Non-static method AECCore::can_edit() should not be called statically - /var/www/html/wp-content/plugins/wp-ajax-edit-comments/lib/class.filters.php:35

3. **E_STRICT** Only variables should be assigned by reference - /var/www/html/wp-content/plugins/wp-ajax-edit-comments/lib/class.core.php:18